### PR TITLE
feat: port stdin loading/override logic from Restish

### DIFF
--- a/cmd/j/main.go
+++ b/cmd/j/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/danielgtaylor/shorthand"
 	toml "github.com/pelletier/go-toml"
@@ -21,7 +20,7 @@ func main() {
 		Example: fmt.Sprintf("%s foo.bar: 1, .baz: true", os.Args[0]),
 		Args:    cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			result, err := shorthand.ParseAndBuild("stdin", strings.Join(args, " "))
+			result, err := shorthand.GetInput(args)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
This copies over some logic from [Restish](https://rest.sh) to simplify reading data from `os.Stdin` as well as merging it with data passed as command line arguments. Use the new `shorthand.GetInput(args)` function for this purpose.