### PR TITLE
fix: parsing bug with projection query slicing, add test

### DIFF
--- a/get.go
+++ b/get.go
@@ -38,9 +38,12 @@ func GetPath(path string, input any, options GetOptions) (any, bool, Error) {
 }
 
 func (d *Document) parseUntil(open int, terminators ...rune) (quoted bool, canSlice bool, err Error) {
-	canSlice = true
 	d.buf.Reset()
+	return d.parseUntilNoReset(open, terminators...)
+}
 
+func (d *Document) parseUntilNoReset(open int, terminators ...rune) (quoted bool, canSlice bool, err Error) {
+	canSlice = true
 outer:
 	for {
 		p := d.peek()
@@ -491,6 +494,11 @@ func (d *Document) getFields(input any) (any, Error) {
 		}
 		if r == -1 {
 			break
+		}
+		if r == '[' {
+			d.buf.WriteRune(r)
+			d.parseUntilNoReset(1, '|')
+			continue
 		}
 		if r == ':' {
 			key = d.buf.String()

--- a/get_test.go
+++ b/get_test.go
@@ -257,6 +257,12 @@ var getExamples = []struct {
 		Go:    map[string]any{"foo": "bar", "id": 1.0, "tags": "a"},
 	},
 	{
+		Name:  "Field expression with slices",
+		Input: `{"items": [1, 2, 3, 4, 5]}`,
+		Query: `{first: items[:2], filtered: items[@ > 1]|[:1], last: items[-1:]}`,
+		Go:    map[string]any{"first": []any{1.0, 2.0, 3.0}, "filtered": []any{2.0, 3.0}, "last": []any{5.0}},
+	},
+	{
 		Name:  "Unclosed filter",
 		Input: `{}`,
 		Query: `foo[`,


### PR DESCRIPTION
This fixes a bug that could easily be reproduced via Restish:

```sh
restish api.rest.sh/example -f 'body.work.{name, highlights: highlights[0:2]}'
```

This resulted in a key like `highlights[0` instead of parsing the slice properly. This PR fixes that and adds a new test to capture this use case.