### PR TITLE
fix(GetPath): string truncation nil result

### DIFF
--- a/get.go
+++ b/get.go
@@ -201,7 +201,10 @@ func (d *Document) getPathIndex(input any) (any, Error) {
 	if stopIndex < 0 {
 		stopIndex += l
 	}
-	if startIndex < 0 || startIndex > l-1 || stopIndex < 0 || stopIndex > l-1 || startIndex > stopIndex {
+	if stopIndex > l-1 {
+		stopIndex = l - 1
+	}
+	if startIndex < 0 || startIndex > l-1 || stopIndex < 0 || startIndex > stopIndex {
 		return nil, nil
 	}
 

--- a/get_test.go
+++ b/get_test.go
@@ -146,6 +146,12 @@ var getExamples = []struct {
 		Go:    "ello",
 	},
 	{
+		Name:  "Truncate string",
+		Input: `{"field": "hello"}`,
+		Query: `field[:30]`,
+		Go:    "hello",
+	},
+	{
 		Name:  "Index bytes",
 		Input: map[string]any{"field": []byte("hello")},
 		Query: `field[1]`,


### PR DESCRIPTION
This fixes a bug where an attempt to use string truncation via e.g. `field[:10]` would result in `nil` if the input string is shorter than 10 characters. The desired behavior is that it should include the entire string so you can provide a limit of how many characters to include.