### PR TITLE
fix: upgrade mexpr to v1.7.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/danielgtaylor/shorthand/v2
 go 1.18
 
 require (
-	github.com/danielgtaylor/mexpr v1.7.2
+	github.com/danielgtaylor/mexpr v1.7.3
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/spf13/cobra v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/danielgtaylor/mexpr v1.7.2 h1:NDAIvh3BIE8jDSjJEO/EqTNxuguaNbNEH/LPTDbM4bQ=
 github.com/danielgtaylor/mexpr v1.7.2/go.mod h1:Jcg0kPd2IPMV8ZxnpOj/UbNwMbM9As23hi8yxKsrI0U=
+github.com/danielgtaylor/mexpr v1.7.3 h1:mEW3GKsrywh/KERIDgb13xr/fgAN+063jXOw54C7Sj4=
+github.com/danielgtaylor/mexpr v1.7.3/go.mod h1:Jcg0kPd2IPMV8ZxnpOj/UbNwMbM9As23hi8yxKsrI0U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This fixes a bug with empty `where` clause left results, along with enabling type checking for unquoted strings.