### PR TITLE
feat: bump mexpr to 1.8.0, where clause for maps and fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/danielgtaylor/shorthand/v2
 go 1.18
 
 require (
-	github.com/danielgtaylor/mexpr v1.7.3
+	github.com/danielgtaylor/mexpr v1.8.0
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/exp v0.0.0-20221019170559-20944726eadf
+	golang.org/x/exp v0.0.0-20230111222715-75897c7a292a
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/danielgtaylor/mexpr v1.7.2 h1:NDAIvh3BIE8jDSjJEO/EqTNxuguaNbNEH/LPTDb
 github.com/danielgtaylor/mexpr v1.7.2/go.mod h1:Jcg0kPd2IPMV8ZxnpOj/UbNwMbM9As23hi8yxKsrI0U=
 github.com/danielgtaylor/mexpr v1.7.3 h1:mEW3GKsrywh/KERIDgb13xr/fgAN+063jXOw54C7Sj4=
 github.com/danielgtaylor/mexpr v1.7.3/go.mod h1:Jcg0kPd2IPMV8ZxnpOj/UbNwMbM9As23hi8yxKsrI0U=
+github.com/danielgtaylor/mexpr v1.8.0 h1:Dx9nLzakvveIJ8CYhxfFdTiulMITec/Uiv6kmvACyDk=
+github.com/danielgtaylor/mexpr v1.8.0/go.mod h1:+JIK75BxmwIf+iIfXM2aLVqED3l2EMPBB8QKct8YEDs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -33,6 +35,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/exp v0.0.0-20221019170559-20944726eadf h1:nFVjjKDgNY37+ZSYCJmtYf7tOlfQswHqplG2eosjOMg=
 golang.org/x/exp v0.0.0-20221019170559-20944726eadf/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20230111222715-75897c7a292a h1:/YWeLOBWYV5WAQORVPkZF3Pq9IppkcT72GKnWjNf5W8=
+golang.org/x/exp v0.0.0-20230111222715-75897c7a292a/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
This includes support for filters having a `where` clause for maps and provides better error messages and a few small fixes.

https://github.com/danielgtaylor/mexpr/releases/tag/v1.8.0