### PR TITLE
fix: nested field selection path bug, add test

### DIFF
--- a/get.go
+++ b/get.go
@@ -503,7 +503,7 @@ func (d *Document) getFields(input any) (any, Error) {
 			d.parseUntilNoReset(1, '|')
 			continue
 		}
-		if r == ':' {
+		if r == ':' && open <= 1 {
 			key = d.buf.String()
 			d.buf.Reset()
 			d.skipWhitespace()

--- a/get_test.go
+++ b/get_test.go
@@ -257,6 +257,12 @@ var getExamples = []struct {
 		Go:    map[string]any{"body": []any{map[string]any{"id": "a", "created": "2022"}}, "one": 1.0},
 	},
 	{
+		Name:  "Field expression nested multi path",
+		Input: `{"body": [{"id": "a", "created": "2022", "link": "..."}], "headers": {"one": 1, "two": 2}}`,
+		Query: `{body: body.{id, created: created}, one: headers.one}`,
+		Go:    map[string]any{"body": []any{map[string]any{"id": "a", "created": "2022"}}, "one": 1.0},
+	},
+	{
 		Name:  "Field expression with pipe",
 		Input: `{"foo": "bar", "link": {"id": 1, "verified": true, "tags": ["a", "b"]}}`,
 		Query: `{foo, tags: link.tags[@ startsWith a]|[0], id: link.id}`,


### PR DESCRIPTION
This is triggered by a field selection path within another one, e.g. `foo.{bar: {baz: blah}}`. This fixes it so that `:` no longer resets the field key when inside nested curly braces.