### PR TITLE
Improve coverage for edge cases

### DIFF
--- a/apply_test.go
+++ b/apply_test.go
@@ -327,6 +327,59 @@ func TestApplyDeleteAppendIndexNoOp(t *testing.T) {
 	}, result)
 }
 
+func TestApplySwapMissingPathBehaviors(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]any
+		input    string
+		want     map[string]any
+	}{
+		{
+			name:     "Move into missing path",
+			existing: map[string]any{"foo": "hello"},
+			input:    "{bar ^ foo}",
+			want:     map[string]any{"bar": "hello"},
+		},
+		{
+			name:     "Move out of missing path",
+			existing: map[string]any{"bar": "hello"},
+			input:    "{bar ^ foo}",
+			want:     map[string]any{"foo": "hello"},
+		},
+		{
+			name:     "Swap with both sides missing is no-op",
+			existing: map[string]any{"keep": true},
+			input:    "{bar ^ foo}",
+			want:     map[string]any{"keep": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDocument(ParseOptions{})
+			require.NoError(t, d.Parse(tt.input))
+
+			result, err := d.Apply(tt.existing)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestApplyForceFloat64NumbersOnPathKeys(t *testing.T) {
+	d := NewDocument(ParseOptions{ForceFloat64Numbers: true})
+	require.NoError(t, d.Parse(`{items.1: value}`))
+
+	result, err := d.Apply(nil)
+	require.NoError(t, err)
+	root, ok := result.(map[string]any)
+	require.True(t, ok)
+
+	items, ok := root["items"].(map[any]any)
+	require.True(t, ok)
+	assert.Equal(t, "value", items[1.0])
+}
+
 func TestApply(t *testing.T) {
 	for _, example := range applyExamples {
 		t.Run(example.Name, func(t *testing.T) {

--- a/cmd/j/main_test.go
+++ b/cmd/j/main_test.go
@@ -42,6 +42,26 @@ func TestMarshalOutputShorthandMatchesLibrary(t *testing.T) {
 	}
 }
 
+func TestMarshalOutputUnsupportedFormat(t *testing.T) {
+	_, err := marshalOutput(map[string]any{"hello": "world"}, "ini")
+	if err == nil {
+		t.Fatal("expected an error for unsupported format")
+	}
+	if !strings.Contains(err.Error(), `unsupported format "ini"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMarshalOutputTOMLRejectsNonMap(t *testing.T) {
+	_, err := marshalOutput([]any{"hello"}, "toml")
+	if err == nil {
+		t.Fatal("expected an error for non-map TOML input")
+	}
+	if !strings.Contains(err.Error(), "TOML only supports maps") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 type fakeFileInfo struct {
 	mode fs.FileMode
 }

--- a/get.go
+++ b/get.go
@@ -15,7 +15,7 @@ type GetOptions struct {
 	DebugLogger func(format string, a ...any)
 }
 
-var propPathUnescaper = strings.NewReplacer(`\.`, ".", `\{`, "{", `\[`, "[", `\:`, ":", `\^`, "^")
+var propPathUnescaper = strings.NewReplacer(`\.`, ".", `\{`, "{", `\[`, "[", `\]`, "]", `\:`, ":", `\^`, "^")
 
 // unescapePropPath removes prop-escaping backslashes added by parseQuoted(escapeProp=true).
 func unescapePropPath(s string) string {

--- a/get_test.go
+++ b/get_test.go
@@ -403,6 +403,85 @@ func TestGetPathFound(t *testing.T) {
 	assert.NotEmpty(t, result)
 }
 
+func TestGetPathAdditionalEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  any
+		query  string
+		want   any
+		found  bool
+		errMsg string
+	}{
+		{
+			name:  "Escaped unquoted property path",
+			input: map[string]any{"a.b": map[string]any{"c[d]": "ok"}},
+			query: `a\.b.c\[d\]`,
+			want:  "ok",
+			found: true,
+		},
+		{
+			name:  "Negative unicode string slice",
+			input: map[string]any{"field": "a😈bc"},
+			query: `field[-2:]`,
+			want:  "bc",
+			found: true,
+		},
+		{
+			name:  "Negative byte slice",
+			input: map[string]any{"field": []byte("hello")},
+			query: `field[-2:]`,
+			want:  []byte("lo"),
+			found: true,
+		},
+		{
+			name:  "Flatten non array returns nil",
+			input: map[string]any{"field": "hello"},
+			query: `field|[]`,
+			want:  nil,
+			found: true,
+		},
+		{
+			name:  "Filter with nested path on scalar input is empty",
+			input: map[string]any{"items": []any{"a", "b"}},
+			query: `items[@.missing]`,
+			want:  []any{},
+			found: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found, err := GetPath(tt.query, tt.input, GetOptions{})
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.found, found)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetFieldSelectionUnescapesOutputKeys(t *testing.T) {
+	input := map[string]any{
+		"link": map[string]any{
+			"foo.bar": 1,
+			"a[b]":    2,
+		},
+	}
+
+	result, found, err := GetPath(`link.{"foo.bar", "a[b]"}`, input, GetOptions{})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, map[string]any{
+		"foo.bar": 1,
+		"a[b]":    2,
+	}, result)
+}
+
 var getBenchInput = map[string]any{
 	"items": []any{
 		0,

--- a/parse.go
+++ b/parse.go
@@ -300,7 +300,7 @@ func (d *Document) parseQuoted(escapeProp bool) Error {
 		}
 
 		if escapeProp {
-			if r == '.' || r == '{' || r == '[' || r == ':' || r == '^' {
+			if r == '.' || r == '{' || r == '[' || r == ':' || r == '^' || r == ']' {
 				d.buf.WriteRune('\\')
 			}
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -2,6 +2,8 @@ package shorthand
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -220,6 +222,74 @@ b	{
 		}`,
 		Error: "{c: 1\n\t\t\t]\n...^",
 	},
+}
+
+func TestParserAdditionalErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "Object closing bracket mismatch",
+			input: `{a]`,
+			err:   "Expected property or '}' while parsing object but got ']'",
+		},
+		{
+			name:  "Missing property name",
+			input: `{ : 1 }`,
+			err:   "expected at least one property name",
+		},
+		{
+			name:  "Index unexpected terminator",
+			input: `{a[1}: 2}`,
+			err:   "Expected ']' but found }",
+		},
+		{
+			name:  "Missing colon before value",
+			input: `{a b}`,
+			err:   "Expected colon but got }",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDocument(ParseOptions{
+				EnableObjectDetection: true,
+			})
+			err := d.Parse(tt.input)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.err)
+		})
+	}
+}
+
+func TestParserInvalidJSONFileInclude(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("{nope"), 0o644))
+
+	d := NewDocument(ParseOptions{
+		EnableFileInput: true,
+		EnableObjectDetection: true,
+	})
+	err := d.Parse("a: @" + path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unable to unmarshal JSON")
+}
+
+func TestParserInvalidCBORFileInclude(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.cbor")
+	require.NoError(t, os.WriteFile(path, []byte("not-cbor"), 0o644))
+
+	d := NewDocument(ParseOptions{
+		EnableFileInput: true,
+		EnableObjectDetection: true,
+	})
+	err := d.Parse("a: @" + path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unable to unmarshal CBOR")
 }
 
 func TestParser(t *testing.T) {

--- a/shorthand_test.go
+++ b/shorthand_test.go
@@ -95,6 +95,26 @@ func TestGetInput(t *testing.T) {
 	}
 }
 
+func TestGetInputInvalidUTF8StructuredEdit(t *testing.T) {
+	result, isStruct, err := getInput(0, strings.NewReader(string([]byte{0xff})), []string{"a: 1"}, ParseOptions{})
+	require.ErrorIs(t, err, ErrInvalidFile)
+	assert.False(t, isStruct)
+	assert.Nil(t, result)
+}
+
+func TestGetInputForceFloat64Numbers(t *testing.T) {
+	result, isStruct, err := getInput(0, strings.NewReader(`{"count": 1}`), []string{"value: 2"}, ParseOptions{
+		ForceFloat64Numbers: true,
+		EnableObjectDetection: true,
+	})
+	require.NoError(t, err)
+	require.True(t, isStruct)
+	assert.Equal(t, map[string]any{
+		"count": 1.0,
+		"value": 2.0,
+	}, result)
+}
+
 var marshalExamples = []struct {
 	Name   string
 	Input  any
@@ -296,6 +316,32 @@ func TestMarshalCLINonStringMapKeysStayUnquoted(t *testing.T) {
 		"2": "two",
 	})
 	assert.Equal(t, `1: one, "2": two`, out)
+}
+
+func TestMarshalCLIQuotesReservedPrefixesAndWhitespaceKeys(t *testing.T) {
+	out := MarshalCLI(map[string]any{
+		" spaced ": "@file",
+		"pct":      "%not-really-base64",
+	})
+	assert.Equal(t, `" spaced ": "@file", pct: "%not-really-base64"`, out)
+}
+
+func TestConvertMapStringRecursivelyConvertsNestedKeys(t *testing.T) {
+	input := map[any]any{
+		1: map[any]any{
+			true: []any{
+				map[any]any{2: "value"},
+			},
+		},
+	}
+
+	assert.Equal(t, map[string]any{
+		"1": map[string]any{
+			"true": []any{
+				map[string]any{"2": "value"},
+			},
+		},
+	}, ConvertMapString(input))
 }
 
 func TestUnmarshalCommentDisambiguation(t *testing.T) {


### PR DESCRIPTION
## Summary
- add coverage for parser, getter, apply, CLI, and input edge cases
- fix quoted field-selection handling for keys containing closing brackets
- expand regression coverage around file decoding, float coercion, swaps, and marshaling

## Testing
- env GOCACHE=/tmp/shorthand-gocache go test ./...
- env GOCACHE=/tmp/shorthand-gocache go test ./... -cover